### PR TITLE
Removal of Glossary Button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1021,7 +1021,8 @@
 
   <div id="modalEscapeFrame">
     <div id="escapeMenu">
-      <div class="mainEscapeButton" id="directoryButton" onclick="toggleEscapeFrame(); toggleIndex() ;">Glossary</div>
+      <!--Commented out Glossary button, which is div below. Reference Issue 363 on explanation for removal.-->
+      <!--<div class="mainEscapeButton" id="directoryButton" onclick="toggleEscapeFrame(); toggleIndex() ;">Glossary</div> -->
       <div class="mainEscapeButton" id="optionsButton" onclick="toggleEscapeFrame(); startOptions();">Instructor Options</div>
       <!--The hover options feature is currently in the Options menu, but can be changed -->
       <!--<div class="mainEscapeButton" id="userSettingsButton" onclick="toggleEscapeFrame(); startOptions();">User Settings</div>-->


### PR DESCRIPTION
Commented out Glossary button line, which is line 2015 in this commit. Reference Issu 363 for explanation for removal.