### PR TITLE
Issue507 - moved progress bars up so all information stays on screen

### DIFF
--- a/lib/bootstrap-progressbar-3.3.4.css
+++ b/lib/bootstrap-progressbar-3.3.4.css
@@ -85,7 +85,8 @@
 
 .progressBarContainer {
   position: absolute;
-  top: 15vw;
+  /* top: 15vw; */
+  top: 13vw;
   right: 5vw;
 }
 


### PR DESCRIPTION
All information fits on the screen when all of the progress bars are selected.