### PR TITLE
Issue597 Ensured singularity of the Contour map when a new board is created 

### DIFF
--- a/front-end/contourMap.js
+++ b/front-end/contourMap.js
@@ -4,7 +4,6 @@
  */
 function confirmTopoMapGenerate() {
   if (window.confirm("Do you want to generate a new contour map?")) {
-    generatedContourMap = new ContourMap();
     generatedContourMap.drawContours();
   }
 }

--- a/front-end/mainFE.js
+++ b/front-end/mainFE.js
@@ -950,7 +950,7 @@ function switchBoards(newBoard) {
 
   //update Results to point to correct board since currentBoard is updated
   Totals = new Results(boardData[currentBoard]);
-  generatedContourMap = new ContourMap();
+  generatedContourMap = generatedContourMap || new ContourMap(); //to ensure that we don't make a new map if we don't need to.
 
 } //end switchBoards
 


### PR DESCRIPTION
#597.
Every time the initialization phase of the board occurred the Contour Map object would be recreated. I added a check to ensure that recreation does not happen.