### PR TITLE
Issue617 Multiplayer drawing

### DIFF
--- a/front-end/helpersFE.js
+++ b/front-end/helpersFE.js
@@ -198,7 +198,6 @@ function toggleTabTitle(value, dir) {
         document.getElementById(value).innerHTML = 'yield&nbsp;base&nbsp;rates';
         break;
     }
-
     document.getElementById(value).style.display = 'inline-block';
   } else {
     document.getElementById(value).style.display = 'none';
@@ -3736,6 +3735,9 @@ function multiplayerMode() {
     document.getElementById('pewiLogo').style.right = '18.5vw';
     // Hide the progress bar
     document.getElementById('progressBarContainer').style.display = 'none';
+    for(let i = 1; i <= 15; i++){
+      document.getElementById('paint' + i).style.display = 'none';
+    }
   }
 }
 

--- a/htmlFrames/multiDownload.html
+++ b/htmlFrames/multiDownload.html
@@ -78,8 +78,6 @@ function addToZip(playerNumber) {
 }//end addToZip
 
 function createMultimapDownload() {
-  window.top.document.getElementById('parameters').innerHTML = "cornGrainProgressBar" + "\n" + "soybeansProgressBar"+"\n"+"fruitsAndVegetablesProgressBar"+"\n"+"cattleProgressBar"+"\n"+"alfalfaHayProgressBar"+"\n"+
-                                                  "grassHayProgressBar"+"\n"+"switchgrassBiomassProgressBar"+"\n"+"woodProgressBar"+"\n"+"woodyBiomassProgressBar";
     //get the number of players from the toggle tool
     var assignedPlayers = parent.getNumberOfPlayers();// Number(document.getElementById('playerNumber').innerHTML);
     //for each player, add their map to the zip folder

--- a/htmlFrames/multiDownload.html
+++ b/htmlFrames/multiDownload.html
@@ -78,6 +78,8 @@ function addToZip(playerNumber) {
 }//end addToZip
 
 function createMultimapDownload() {
+  window.top.document.getElementById('parameters').innerHTML = "cornGrainProgressBar" + "\n" + "soybeansProgressBar"+"\n"+"fruitsAndVegetablesProgressBar"+"\n"+"cattleProgressBar"+"\n"+"alfalfaHayProgressBar"+"\n"+
+                                                  "grassHayProgressBar"+"\n"+"switchgrassBiomassProgressBar"+"\n"+"woodProgressBar"+"\n"+"woodyBiomassProgressBar";
     //get the number of players from the toggle tool
     var assignedPlayers = parent.getNumberOfPlayers();// Number(document.getElementById('playerNumber').innerHTML);
     //for each player, add their map to the zip folder

--- a/htmlFrames/options_script.js
+++ b/htmlFrames/options_script.js
@@ -171,7 +171,6 @@
   function getCurrentOptionsState() {
     //raw text content in parameters div
     var strRawContents = window.top.document.getElementById('parameters').innerHTML;
-    console.log(strRawContents);
       // console.log("in the get current options state method"+strRawContents);
     //split based on escape chars
     while (strRawContents.indexOf("\r") >= 0) {

--- a/levels/specs/multiplayerAssign.txt
+++ b/levels/specs/multiplayerAssign.txt
@@ -1,4 +1,4 @@
-﻿paint15*paint1*paint2*paint3*paint4*paint5*paint12*paint6*paint7*paint8*paint11*paint10*paint13*paint9*paint14*multiAssign*precipOff*year2Button*year3Button*resultsButton
+﻿cornGrainProgressBar*soybeansProgressBar*fruitsAndVegetablesProgressBar*cattleProgressBar*alfalfaHayProgressBar*grassHayProgressBar*switchgrassBiomassProgressBar*woodProgressBar*woodyBiomassProgressBar*multiAssign
 24.58*30.39*34.34*28.18
 1*1*1
 <p style='font-weight:900;'>Multiplayer Assignment Mode</p><br><p> Using the choice options to the left, divide up the watershed into a maximum of 6 'landowner' players properties. <br /> <br />  When you’ve completed your landownership assignments, Click the 'Download' button or press the ‘v’ key to create the multiplayer maps.</p>


### PR DESCRIPTION
#617 
Previously it worked by only keeping track of changes and creating options based off of the changes. This method worked fine for multiplayer, but does not work when trying to resave a file, since there were no options changes. So when it was changed to use the options in their entirety, the multiplayer options were carried over from their save files. Previously in multiplayer all land uses were turned off so that their buttons won't show up. 
I have changed the options file for multiplayer so now it will match what we expect in the normal version. This would make all of the buttons reappear, but I manually turn them off now when initializing assign mode.
I believe the options being the same across versions will make things a lot easier in the long run.